### PR TITLE
feat: Todo CRUD UC

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ package_dir =
 
 install_requires =
     pydantic~=1.8.2
+    deepdiff~=5.6.0
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ testing =
     setuptools
     pytest~=6.2.5
     pytest-cov~=3.0.0
-    python-mock~=3.6.1
+    pytest-mock~=3.6.1
 
 security-check =
     safety~=1.10.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,6 +89,9 @@ warn_redundant_casts = True
 warn_no_return = True
 warn_return_any = True
 
+[mypy-deepdiff]
+ignore_missing_imports = True
+
 [isort]
 py_version = 37
 line_length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,12 +58,16 @@ lint =
     flake8~=4.0.1
     isort~=5.10.0
     black~=21.10b0
+
+typing =
     mypy~=0.910
+    types-toml~=0.10.1
 
 all =
     %(testing)s
     %(security-check)s
     %(lint)s
+    %(typing)s
 
 
 [tool:pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ testing =
     setuptools
     pytest~=6.2.5
     pytest-cov~=3.0.0
+    python-mock~=3.6.1
 
 security-check =
     safety~=1.10.3

--- a/src/todo_sample/entities/todo.py
+++ b/src/todo_sample/entities/todo.py
@@ -1,10 +1,17 @@
+import typing as _t
 import uuid
 from datetime import datetime
 
 from pydantic import BaseModel, Field, validator
 
 
-class Todo(BaseModel):
+class TodoUpdate(BaseModel):
+    title: _t.Optional[str] = None
+    description: _t.Optional[str] = None
+    done: _t.Optional[bool] = None
+
+
+class Todo(TodoUpdate):
     id: uuid.UUID = Field(default_factory=uuid.uuid4)
     title: str
     description: str

--- a/src/todo_sample/use_cases/create_todo.py
+++ b/src/todo_sample/use_cases/create_todo.py
@@ -15,6 +15,6 @@ class CreateTodo:
         try:
             self.todo_repo.save(todo=todo, create_only=True)
         except AlreadyExistError as exc:
-            raise TodoAlreadyExistException(f"Todo with same id:{todo.id} already exist.") from exc
+            raise TodoAlreadyExistException(id=todo.id) from exc
 
         return todo

--- a/src/todo_sample/use_cases/create_todo.py
+++ b/src/todo_sample/use_cases/create_todo.py
@@ -2,7 +2,7 @@ from todo_sample.entities.todo import Todo
 from todo_sample.repository.exception import AlreadyExistError
 from todo_sample.repository.todo_repository import TodoRepository
 
-from .exceptions import CreateTodoAlreadyExistException
+from .exceptions import TodoAlreadyExistException
 
 
 class CreateTodo:
@@ -15,6 +15,6 @@ class CreateTodo:
         try:
             self.todo_repo.save(todo=todo, create_only=True)
         except AlreadyExistError as exc:
-            raise CreateTodoAlreadyExistException(f"Todo with same id:{todo.id} already exist.") from exc
+            raise TodoAlreadyExistException(f"Todo with same id:{todo.id} already exist.") from exc
 
         return todo

--- a/src/todo_sample/use_cases/create_todo.py
+++ b/src/todo_sample/use_cases/create_todo.py
@@ -1,0 +1,20 @@
+from todo_sample.entities.todo import Todo
+from todo_sample.repository.exception import AlreadyExistError
+from todo_sample.repository.todo_repository import TodoRepository
+
+from .exceptions import CreateTodoAlreadyExistException
+
+
+class CreateTodo:
+    def __init__(self, todo_repo: TodoRepository) -> None:
+        self.todo_repo = todo_repo
+
+    def call(self, title: str, description: str) -> Todo:
+        todo = Todo(title=title, description=description)
+
+        try:
+            self.todo_repo.save(todo=todo, create_only=True)
+        except AlreadyExistError as exc:
+            raise CreateTodoAlreadyExistException(f"Todo with same id:{todo.id} already exist.") from exc
+
+        return todo

--- a/src/todo_sample/use_cases/delete_todo.py
+++ b/src/todo_sample/use_cases/delete_todo.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from todo_sample.entities.todo import Todo
 from todo_sample.repository.todo_repository import TodoRepository
 
-from .exceptions import GetTodoInvalidIdFormatException, GetTodoNotFoundException
+from .exceptions import TodoInvalidIdFormatException, TodoNotFoundException
 
 
 class DeleteTodo:
@@ -17,8 +17,8 @@ class DeleteTodo:
             id (str): UUID4 format ID
 
         Raises:
-            GetTodoInvalidIdFormatException: when the `id` parameter does not respect UUID4 format
-            GetTodoNotFoundException: when no Todo matching id has been found
+            TodoInvalidIdFormatException: when the `id` parameter does not respect UUID4 format
+            TodoNotFoundException: when no Todo matching id has been found
 
         Returns:
 
@@ -26,12 +26,12 @@ class DeleteTodo:
         try:
             id_uuid = UUID(id)
         except ValueError as exc:
-            raise GetTodoInvalidIdFormatException(f"{id} is not a valid UUID4 format.") from exc
+            raise TodoInvalidIdFormatException(f"{id} is not a valid UUID4 format.") from exc
 
         todo = self.todo_repo.find_by_id(id=id_uuid)
 
         if not todo:
-            raise GetTodoNotFoundException(f"Todo with id:{id} not found.")
+            raise TodoNotFoundException(f"Todo with id:{id} not found.")
 
         self.todo_repo.delete(id=id_uuid)
 

--- a/src/todo_sample/use_cases/delete_todo.py
+++ b/src/todo_sample/use_cases/delete_todo.py
@@ -1,8 +1,6 @@
-from uuid import UUID
-
 from todo_sample.repository.todo_repository import TodoRepository
 
-from .exceptions import TodoInvalidIdFormatException, TodoNotFoundException
+from .get_todo import GetTodo
 
 
 class DeleteTodo:
@@ -22,16 +20,8 @@ class DeleteTodo:
         Returns:
 
         """
-        try:
-            id_uuid = UUID(id)
-        except ValueError as exc:
-            raise TodoInvalidIdFormatException(f"{id} is not a valid UUID4 format.") from exc
+        todo = GetTodo(todo_repo=self.todo_repo).call(id=id)
 
-        todo = self.todo_repo.find_by_id(id=id_uuid)
-
-        if not todo:
-            raise TodoNotFoundException(id=id_uuid)
-
-        self.todo_repo.delete(id=id_uuid)
+        self.todo_repo.delete(id=todo.id)
 
         return None

--- a/src/todo_sample/use_cases/delete_todo.py
+++ b/src/todo_sample/use_cases/delete_todo.py
@@ -1,6 +1,6 @@
 from todo_sample.repository.todo_repository import TodoRepository
 
-from .get_todo import GetTodo
+from . import get_todo
 
 
 class DeleteTodo:
@@ -20,7 +20,7 @@ class DeleteTodo:
         Returns:
 
         """
-        todo = GetTodo(todo_repo=self.todo_repo).call(id=id)
+        todo = get_todo.GetTodo(todo_repo=self.todo_repo).call(id=id)
 
         self.todo_repo.delete(id=todo.id)
 

--- a/src/todo_sample/use_cases/delete_todo.py
+++ b/src/todo_sample/use_cases/delete_todo.py
@@ -31,7 +31,7 @@ class DeleteTodo:
         todo = self.todo_repo.find_by_id(id=id_uuid)
 
         if not todo:
-            raise TodoNotFoundException(f"Todo with id:{id} not found.")
+            raise TodoNotFoundException(id=id_uuid)
 
         self.todo_repo.delete(id=id_uuid)
 

--- a/src/todo_sample/use_cases/delete_todo.py
+++ b/src/todo_sample/use_cases/delete_todo.py
@@ -1,0 +1,38 @@
+from uuid import UUID
+
+from todo_sample.entities.todo import Todo
+from todo_sample.repository.todo_repository import TodoRepository
+
+from .exceptions import GetTodoInvalidIdFormatException, GetTodoNotFoundException
+
+
+class DeleteTodo:
+    def __init__(self, todo_repo: TodoRepository) -> None:
+        self.todo_repo = todo_repo
+
+    def call(self, id: str) -> Todo:
+        """Delete a Todo by its ID
+
+        Args:
+            id (str): UUID4 format ID
+
+        Raises:
+            GetTodoInvalidIdFormatException: when the `id` parameter does not respect UUID4 format
+            GetTodoNotFoundException: when no Todo matching id has been found
+
+        Returns:
+
+        """
+        try:
+            id_uuid = UUID(id)
+        except ValueError as exc:
+            raise GetTodoInvalidIdFormatException(f"{id} is not a valid UUID4 format.") from exc
+
+        todo = self.todo_repo.find_by_id(id=id_uuid)
+
+        if not todo:
+            raise GetTodoNotFoundException(f"Todo with id:{id} not found.")
+
+        self.todo_repo.delete(id=id_uuid)
+
+        return None

--- a/src/todo_sample/use_cases/delete_todo.py
+++ b/src/todo_sample/use_cases/delete_todo.py
@@ -1,6 +1,5 @@
 from uuid import UUID
 
-from todo_sample.entities.todo import Todo
 from todo_sample.repository.todo_repository import TodoRepository
 
 from .exceptions import TodoInvalidIdFormatException, TodoNotFoundException
@@ -10,7 +9,7 @@ class DeleteTodo:
     def __init__(self, todo_repo: TodoRepository) -> None:
         self.todo_repo = todo_repo
 
-    def call(self, id: str) -> Todo:
+    def call(self, id: str) -> None:
         """Delete a Todo by its ID
 
         Args:

--- a/src/todo_sample/use_cases/exceptions.py
+++ b/src/todo_sample/use_cases/exceptions.py
@@ -4,3 +4,11 @@ class CreateTodoException(Exception):
 
 class CreateTodoAlreadyExistException(CreateTodoException):
     """CreateTodoAlreadyExistException"""
+
+
+class GetTodoInvalidIdFormatException(Exception):
+    """GetTodoInvalidIdFormatException"""
+
+
+class GetTodoNotFoundException(Exception):
+    """GetTodoNotFoundException"""

--- a/src/todo_sample/use_cases/exceptions.py
+++ b/src/todo_sample/use_cases/exceptions.py
@@ -1,20 +1,14 @@
 from uuid import UUID
 
 
-class CreateTodoException(Exception):
-    """CreateTodoException"""
-
-    pass
-
-
-class CreateTodoAlreadyExistException(CreateTodoException):
-    """CreateTodoAlreadyExistException"""
-
-    pass
-
-
 class TodoException(Exception):
     """TodoException"""
+
+    pass
+
+
+class CreateTodoAlreadyExistException(TodoException):
+    """CreateTodoAlreadyExistException"""
 
     pass
 

--- a/src/todo_sample/use_cases/exceptions.py
+++ b/src/todo_sample/use_cases/exceptions.py
@@ -1,0 +1,6 @@
+class CreateTodoException(Exception):
+    """CreateTodoException"""
+
+
+class CreateTodoAlreadyExistException(CreateTodoException):
+    """CreateTodoAlreadyExistException"""

--- a/src/todo_sample/use_cases/exceptions.py
+++ b/src/todo_sample/use_cases/exceptions.py
@@ -1,18 +1,28 @@
 class CreateTodoException(Exception):
     """CreateTodoException"""
 
+    pass
+
 
 class CreateTodoAlreadyExistException(CreateTodoException):
     """CreateTodoAlreadyExistException"""
+
+    pass
 
 
 class GetTodoException(Exception):
     """GetTodoException"""
 
+    pass
+
 
 class GetTodoInvalidIdFormatException(GetTodoException):
     """GetTodoInvalidIdFormatException"""
 
+    pass
+
 
 class GetTodoNotFoundException(GetTodoException):
     """GetTodoNotFoundException"""
+
+    pass

--- a/src/todo_sample/use_cases/exceptions.py
+++ b/src/todo_sample/use_cases/exceptions.py
@@ -6,9 +6,13 @@ class CreateTodoAlreadyExistException(CreateTodoException):
     """CreateTodoAlreadyExistException"""
 
 
-class GetTodoInvalidIdFormatException(Exception):
+class GetTodoException(Exception):
+    """GetTodoException"""
+
+
+class GetTodoInvalidIdFormatException(GetTodoException):
     """GetTodoInvalidIdFormatException"""
 
 
-class GetTodoNotFoundException(Exception):
+class GetTodoNotFoundException(GetTodoException):
     """GetTodoNotFoundException"""

--- a/src/todo_sample/use_cases/exceptions.py
+++ b/src/todo_sample/use_cases/exceptions.py
@@ -10,19 +10,19 @@ class CreateTodoAlreadyExistException(CreateTodoException):
     pass
 
 
-class GetTodoException(Exception):
-    """GetTodoException"""
+class TodoException(Exception):
+    """TodoException"""
 
     pass
 
 
-class GetTodoInvalidIdFormatException(GetTodoException):
-    """GetTodoInvalidIdFormatException"""
+class TodoInvalidIdFormatException(TodoException):
+    """TodoInvalidIdFormatException"""
 
     pass
 
 
-class GetTodoNotFoundException(GetTodoException):
-    """GetTodoNotFoundException"""
+class TodoNotFoundException(TodoException):
+    """TodoNotFoundException"""
 
     pass

--- a/src/todo_sample/use_cases/exceptions.py
+++ b/src/todo_sample/use_cases/exceptions.py
@@ -7,8 +7,8 @@ class TodoException(Exception):
     pass
 
 
-class CreateTodoAlreadyExistException(TodoException):
-    """CreateTodoAlreadyExistException"""
+class TodoAlreadyExistException(TodoException):
+    """TodoAlreadyExistException"""
 
     pass
 

--- a/src/todo_sample/use_cases/exceptions.py
+++ b/src/todo_sample/use_cases/exceptions.py
@@ -10,7 +10,11 @@ class TodoException(Exception):
 class TodoAlreadyExistException(TodoException):
     """TodoAlreadyExistException"""
 
-    pass
+    def __init__(self, id: UUID) -> None:
+        self.id = id
+
+    def __str__(self) -> str:
+        return f"Todo with id:{self.id} already exist."
 
 
 class TodoInvalidIdFormatException(TodoException):

--- a/src/todo_sample/use_cases/exceptions.py
+++ b/src/todo_sample/use_cases/exceptions.py
@@ -1,3 +1,6 @@
+from uuid import UUID
+
+
 class CreateTodoException(Exception):
     """CreateTodoException"""
 
@@ -25,4 +28,8 @@ class TodoInvalidIdFormatException(TodoException):
 class TodoNotFoundException(TodoException):
     """TodoNotFoundException"""
 
-    pass
+    def __init__(self, id: UUID) -> None:
+        self.id = id
+
+    def __str__(self) -> str:
+        return f"Todo with id:{self.id} not found."

--- a/src/todo_sample/use_cases/get_todo.py
+++ b/src/todo_sample/use_cases/get_todo.py
@@ -31,6 +31,6 @@ class GetTodo:
         todo = self.todo_repo.find_by_id(id=id_uuid)
 
         if not todo:
-            raise TodoNotFoundException(f"Todo with id:{id} not found.")
+            raise TodoNotFoundException(id=id_uuid)
 
         return todo

--- a/src/todo_sample/use_cases/get_todo.py
+++ b/src/todo_sample/use_cases/get_todo.py
@@ -1,0 +1,36 @@
+from uuid import UUID
+
+from todo_sample.entities.todo import Todo
+from todo_sample.repository.todo_repository import TodoRepository
+
+from .exceptions import GetTodoInvalidIdFormatException, GetTodoNotFoundException
+
+
+class GetTodo:
+    def __init__(self, todo_repo: TodoRepository) -> None:
+        self.todo_repo = todo_repo
+
+    def call(self, id: str) -> Todo:
+        """Retreive a Todo by its ID
+
+        Args:
+            id (str): UUID4 format ID
+
+        Raises:
+            GetTodoInvalidIdFormatException: when the `id` parameter does not respect UUID4 format
+            GetTodoNotFoundException: when no Todo matching id has been found
+
+        Returns:
+            Todo: Todo that match the `id`
+        """
+        try:
+            id_uuid = UUID(id)
+        except ValueError as exc:
+            raise GetTodoInvalidIdFormatException(f"{id} is not a valid UUID4 format.") from exc
+
+        todo = self.todo_repo.find_by_id(id=id_uuid)
+
+        if not todo:
+            raise GetTodoNotFoundException(f"Todo with id:{id} not found.")
+
+        return todo

--- a/src/todo_sample/use_cases/get_todo.py
+++ b/src/todo_sample/use_cases/get_todo.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from todo_sample.entities.todo import Todo
 from todo_sample.repository.todo_repository import TodoRepository
 
-from .exceptions import GetTodoInvalidIdFormatException, GetTodoNotFoundException
+from .exceptions import TodoInvalidIdFormatException, TodoNotFoundException
 
 
 class GetTodo:
@@ -17,8 +17,8 @@ class GetTodo:
             id (str): UUID4 format ID
 
         Raises:
-            GetTodoInvalidIdFormatException: when the `id` parameter does not respect UUID4 format
-            GetTodoNotFoundException: when no Todo matching id has been found
+            TodoInvalidIdFormatException: when the `id` parameter does not respect UUID4 format
+            TodoNotFoundException: when no Todo matching id has been found
 
         Returns:
             Todo: Todo that match the `id`
@@ -26,11 +26,11 @@ class GetTodo:
         try:
             id_uuid = UUID(id)
         except ValueError as exc:
-            raise GetTodoInvalidIdFormatException(f"{id} is not a valid UUID4 format.") from exc
+            raise TodoInvalidIdFormatException(f"{id} is not a valid UUID4 format.") from exc
 
         todo = self.todo_repo.find_by_id(id=id_uuid)
 
         if not todo:
-            raise GetTodoNotFoundException(f"Todo with id:{id} not found.")
+            raise TodoNotFoundException(f"Todo with id:{id} not found.")
 
         return todo

--- a/src/todo_sample/use_cases/get_todos.py
+++ b/src/todo_sample/use_cases/get_todos.py
@@ -1,0 +1,14 @@
+from typing import Iterable
+
+from todo_sample.entities.todo import Todo
+from todo_sample.repository.todo_repository import TodoRepository
+
+
+class GetTodos:
+    def __init__(self, todo_repo: TodoRepository) -> None:
+        self.todo_repo = todo_repo
+
+    def call(self) -> Iterable[Todo]:
+        todos = self.todo_repo.get_all()
+
+        return todos

--- a/src/todo_sample/use_cases/update_todo.py
+++ b/src/todo_sample/use_cases/update_todo.py
@@ -1,0 +1,49 @@
+import typing as _t
+from datetime import datetime
+
+from deepdiff import DeepDiff
+
+from todo_sample.entities.todo import Todo, TodoUpdate
+from todo_sample.repository.todo_repository import TodoRepository
+
+from . import get_todo
+
+
+class UpdateTodo:
+    INCLUDE_FILTER = set(TodoUpdate().dict().keys())
+
+    def __init__(self, todo_repo: TodoRepository) -> None:
+        self.todo_repo = todo_repo
+
+    def call(self, id: str, todo_update: TodoUpdate) -> _t.Optional[Todo]:
+        """Update a Todo given its ID
+
+        Args:
+            id (str): ID of the Todo to update
+            todo (Todo): new object to update
+
+        Raises:
+            TodoInvalidIdFormatException: when the `id` parameter does not respect UUID4 format
+            TodoNotFoundException: when no Todo matching id has been found
+
+        Returns:
+            Todo: update Todo
+        """
+        data_to_update = todo_update.dict(exclude_unset=True)
+        if data_to_update == {}:
+            # nothing to do
+            return None
+
+        todo = get_todo.GetTodo(todo_repo=self.todo_repo).call(id=id)
+
+        todo_updatable_field = todo.dict(include=self.INCLUDE_FILTER)
+        if DeepDiff(data_to_update, todo_updatable_field).get("values_changed") is None:
+            # nothing to do
+            return None
+
+        updated_todo = todo.copy(update=data_to_update)
+        updated_todo.updated_at = datetime.utcnow()
+
+        self.todo_repo.save(todo=updated_todo, create_only=False)
+
+        return updated_todo

--- a/tests/use_cases/test_create_todo.py
+++ b/tests/use_cases/test_create_todo.py
@@ -1,3 +1,7 @@
+from unittest import TestCase
+
+import pytest
+
 from todo_sample.entities.todo import Todo
 from todo_sample.repository.exception import AlreadyExistError
 from todo_sample.use_cases.create_todo import CreateTodo
@@ -6,32 +10,32 @@ from todo_sample.use_cases.exceptions import CreateTodoAlreadyExistException
 MODULE = "todo_sample.use_cases.create_todo"
 
 
-def test_create_todo(mocker):
-    fake_todo = Todo(title="title", description="description")
-    mocker.patch(f"{MODULE}.Todo", mocker.Mock(return_value=fake_todo))
+class TestCreateTodo(TestCase):
+    @pytest.fixture(autouse=True)
+    def _fake_todo_fixture(self, mocker):
+        self.fake_todo = Todo(title="title", description="description")
+        mocker.patch(f"{MODULE}.Todo", mocker.Mock(return_value=self.fake_todo))
 
-    fake_todo_repository = mocker.Mock()
+    @pytest.fixture(autouse=True)
+    def _fake_todo_repo_fixture(self, mocker):
+        self.fake_todo_repository = mocker.Mock()
 
-    create_todo_uc = CreateTodo(todo_repo=fake_todo_repository)
+    def test_create_todo(self):
+        create_todo_uc = CreateTodo(todo_repo=self.fake_todo_repository)
 
-    created_todo = create_todo_uc.call(title="title", description="description")
+        created_todo = create_todo_uc.call(title="title", description="description")
 
-    fake_todo_repository.save.assert_called_once_with(todo=fake_todo, create_only=True)
-    assert created_todo == fake_todo
+        self.fake_todo_repository.save.assert_called_once_with(todo=self.fake_todo, create_only=True)
+        assert created_todo == self.fake_todo
 
+    def test_create_todo_already_exist(self):
+        self.fake_todo_repository.save.side_effect = AlreadyExistError()
 
-def test_create_todo_already_exist(mocker):
-    fake_todo = Todo(title="title", description="description")
-    mocker.patch(f"{MODULE}.Todo", mocker.Mock(return_value=fake_todo))
+        create_todo_uc = CreateTodo(todo_repo=self.fake_todo_repository)
 
-    fake_todo_repository = mocker.Mock()
-    fake_todo_repository.save.side_effect = AlreadyExistError()
+        try:
+            create_todo_uc.call(title="title", description="description")
+        except CreateTodoAlreadyExistException as exc:
+            assert str(self.fake_todo.id) in str(exc)
 
-    create_todo_uc = CreateTodo(todo_repo=fake_todo_repository)
-
-    try:
-        create_todo_uc.call(title="title", description="description")
-    except CreateTodoAlreadyExistException as exc:
-        assert str(fake_todo.id) in str(exc)
-
-    fake_todo_repository.save.assert_called_once_with(todo=fake_todo, create_only=True)
+        self.fake_todo_repository.save.assert_called_once_with(todo=self.fake_todo, create_only=True)

--- a/tests/use_cases/test_create_todo.py
+++ b/tests/use_cases/test_create_todo.py
@@ -19,22 +19,19 @@ class TestCreateTodo(TestCase):
     @pytest.fixture(autouse=True)
     def _fake_todo_repo_fixture(self, mocker):
         self.fake_todo_repository = mocker.Mock()
+        self.create_todo_uc = CreateTodo(todo_repo=self.fake_todo_repository)
 
     def test_create_todo(self):
-        create_todo_uc = CreateTodo(todo_repo=self.fake_todo_repository)
-
-        created_todo = create_todo_uc.call(title="title", description="description")
+        created_todo = self.create_todo_uc.call(title="title", description="description")
 
         self.fake_todo_repository.save.assert_called_once_with(todo=self.fake_todo, create_only=True)
-        assert created_todo == self.fake_todo
+        assert self.fake_todo == created_todo
 
     def test_create_todo_already_exist(self):
         self.fake_todo_repository.save.side_effect = AlreadyExistError()
 
-        create_todo_uc = CreateTodo(todo_repo=self.fake_todo_repository)
-
         try:
-            create_todo_uc.call(title="title", description="description")
+            self.create_todo_uc.call(title="title", description="description")
         except CreateTodoAlreadyExistException as exc:
             assert str(self.fake_todo.id) in str(exc)
 

--- a/tests/use_cases/test_create_todo.py
+++ b/tests/use_cases/test_create_todo.py
@@ -5,7 +5,7 @@ import pytest
 from todo_sample.entities.todo import Todo
 from todo_sample.repository.exception import AlreadyExistError
 from todo_sample.use_cases.create_todo import CreateTodo
-from todo_sample.use_cases.exceptions import CreateTodoAlreadyExistException
+from todo_sample.use_cases.exceptions import TodoAlreadyExistException
 
 MODULE = "todo_sample.use_cases.create_todo"
 
@@ -32,7 +32,7 @@ class TestCreateTodo(TestCase):
 
         try:
             self.create_todo_uc.call(title="title", description="description")
-        except CreateTodoAlreadyExistException as exc:
+        except TodoAlreadyExistException as exc:
             assert str(self.fake_todo.id) in str(exc)
 
         self.fake_todo_repository.save.assert_called_once_with(todo=self.fake_todo, create_only=True)

--- a/tests/use_cases/test_create_todo.py
+++ b/tests/use_cases/test_create_todo.py
@@ -1,0 +1,37 @@
+from todo_sample.entities.todo import Todo
+from todo_sample.repository.exception import AlreadyExistError
+from todo_sample.use_cases.create_todo import CreateTodo
+from todo_sample.use_cases.exceptions import CreateTodoAlreadyExistException
+
+MODULE = "todo_sample.use_cases.create_todo"
+
+
+def test_create_todo(mocker):
+    fake_todo = Todo(title="title", description="description")
+    mocker.patch(f"{MODULE}.Todo", mocker.Mock(return_value=fake_todo))
+
+    fake_todo_repository = mocker.Mock()
+
+    create_todo_uc = CreateTodo(todo_repo=fake_todo_repository)
+
+    created_todo = create_todo_uc.call(title="title", description="description")
+
+    fake_todo_repository.save.assert_called_once_with(todo=fake_todo, create_only=True)
+    assert created_todo == fake_todo
+
+
+def test_create_todo_already_exist(mocker):
+    fake_todo = Todo(title="title", description="description")
+    mocker.patch(f"{MODULE}.Todo", mocker.Mock(return_value=fake_todo))
+
+    fake_todo_repository = mocker.Mock()
+    fake_todo_repository.save.side_effect = AlreadyExistError()
+
+    create_todo_uc = CreateTodo(todo_repo=fake_todo_repository)
+
+    try:
+        create_todo_uc.call(title="title", description="description")
+    except CreateTodoAlreadyExistException as exc:
+        assert str(fake_todo.id) in str(exc)
+
+    fake_todo_repository.save.assert_called_once_with(todo=fake_todo, create_only=True)

--- a/tests/use_cases/test_create_todo.py
+++ b/tests/use_cases/test_create_todo.py
@@ -33,6 +33,6 @@ class TestCreateTodo(TestCase):
         try:
             self.create_todo_uc.call(title="title", description="description")
         except TodoAlreadyExistException as exc:
-            assert str(self.fake_todo.id) in str(exc)
+            assert exc.id == self.fake_todo.id
 
         self.fake_todo_repository.save.assert_called_once_with(todo=self.fake_todo, create_only=True)

--- a/tests/use_cases/test_delete_todo.py
+++ b/tests/use_cases/test_delete_todo.py
@@ -4,7 +4,7 @@ import pytest
 
 from todo_sample.entities.todo import Todo
 from todo_sample.use_cases.delete_todo import DeleteTodo
-from todo_sample.use_cases.exceptions import GetTodoInvalidIdFormatException, GetTodoNotFoundException
+from todo_sample.use_cases.exceptions import TodoInvalidIdFormatException, TodoNotFoundException
 
 MODULE = "todo_sample.use_cases.delete_todo"
 
@@ -32,7 +32,7 @@ class TestGetTodo(TestCase):
         fake_id = "some-wrong-format-id"
         try:
             self.delete_todo_uc.call(id=fake_id)
-        except GetTodoInvalidIdFormatException as exc:
+        except TodoInvalidIdFormatException as exc:
             assert fake_id in str(exc)
 
     def test_get_todo_not_found(self):
@@ -40,7 +40,7 @@ class TestGetTodo(TestCase):
 
         try:
             self.delete_todo_uc.call(id=str(self.fake_todo.id))
-        except GetTodoNotFoundException as exc:
+        except TodoNotFoundException as exc:
             assert str(self.fake_todo.id) in str(exc)
 
         self.fake_todo_repository.find_by_id.assert_called_once_with(id=self.fake_todo.id)

--- a/tests/use_cases/test_delete_todo.py
+++ b/tests/use_cases/test_delete_todo.py
@@ -41,7 +41,7 @@ class TestGetTodo(TestCase):
         try:
             self.delete_todo_uc.call(id=str(self.fake_todo.id))
         except TodoNotFoundException as exc:
-            assert str(self.fake_todo.id) in str(exc)
+            assert exc.id == self.fake_todo.id
 
         self.fake_todo_repository.find_by_id.assert_called_once_with(id=self.fake_todo.id)
         self.fake_todo_repository.delete.assert_not_called()

--- a/tests/use_cases/test_delete_todo.py
+++ b/tests/use_cases/test_delete_todo.py
@@ -20,6 +20,7 @@ class TestGetTodo(TestCase):
         self.delete_todo_uc = DeleteTodo(todo_repo=self.fake_todo_repository)
 
     def test_delete_todo(self):
+        """we could mock GetTodo, but lets try to avoid to much mock (1662232f61aa9a1fe449f66fec97bf63042e5a47)"""
         self.fake_todo_repository.find_by_id.return_value = self.fake_todo
 
         ret = self.delete_todo_uc.call(id=str(self.fake_todo.id))
@@ -29,6 +30,7 @@ class TestGetTodo(TestCase):
         assert ret is None
 
     def test_delete_todo_wrong_id_format(self):
+        """Keeping the test but this is already tested in test_get_todo_wrong_id_format"""
         fake_id = "some-wrong-format-id"
         try:
             self.delete_todo_uc.call(id=fake_id)
@@ -36,6 +38,7 @@ class TestGetTodo(TestCase):
             assert fake_id in str(exc)
 
     def test_get_todo_not_found(self):
+        """Keeping the test but this is already tested in test_get_todo_not_found"""
         self.fake_todo_repository.find_by_id.return_value = None
 
         try:

--- a/tests/use_cases/test_delete_todo.py
+++ b/tests/use_cases/test_delete_todo.py
@@ -1,0 +1,47 @@
+from unittest import TestCase
+
+import pytest
+
+from todo_sample.entities.todo import Todo
+from todo_sample.use_cases.delete_todo import DeleteTodo
+from todo_sample.use_cases.exceptions import GetTodoInvalidIdFormatException, GetTodoNotFoundException
+
+MODULE = "todo_sample.use_cases.delete_todo"
+
+
+class TestGetTodo(TestCase):
+    @pytest.fixture(autouse=True)
+    def _fake_todo_fixture(self, mocker):
+        self.fake_todo = Todo(title="title", description="description")
+
+    @pytest.fixture(autouse=True)
+    def _fake_todo_repo_fixture(self, mocker):
+        self.fake_todo_repository = mocker.Mock()
+        self.delete_todo_uc = DeleteTodo(todo_repo=self.fake_todo_repository)
+
+    def test_delete_todo(self):
+        self.fake_todo_repository.find_by_id.return_value = self.fake_todo
+
+        ret = self.delete_todo_uc.call(id=str(self.fake_todo.id))
+
+        self.fake_todo_repository.find_by_id.assert_called_once_with(id=self.fake_todo.id)
+        self.fake_todo_repository.delete.assert_called_once_with(id=self.fake_todo.id)
+        assert ret is None
+
+    def test_delete_todo_wrong_id_format(self):
+        fake_id = "some-wrong-format-id"
+        try:
+            self.delete_todo_uc.call(id=fake_id)
+        except GetTodoInvalidIdFormatException as exc:
+            assert fake_id in str(exc)
+
+    def test_get_todo_not_found(self):
+        self.fake_todo_repository.find_by_id.return_value = None
+
+        try:
+            self.delete_todo_uc.call(id=str(self.fake_todo.id))
+        except GetTodoNotFoundException as exc:
+            assert str(self.fake_todo.id) in str(exc)
+
+        self.fake_todo_repository.find_by_id.assert_called_once_with(id=self.fake_todo.id)
+        self.fake_todo_repository.delete.assert_not_called()

--- a/tests/use_cases/test_delete_todo.py
+++ b/tests/use_cases/test_delete_todo.py
@@ -1,10 +1,10 @@
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import pytest
 
 from todo_sample.entities.todo import Todo
 from todo_sample.use_cases.delete_todo import DeleteTodo
-from todo_sample.use_cases.exceptions import TodoInvalidIdFormatException, TodoNotFoundException
+from todo_sample.use_cases.exceptions import TodoInvalidIdFormatException
 
 MODULE = "todo_sample.use_cases.delete_todo"
 
@@ -19,12 +19,18 @@ class TestGetTodo(TestCase):
         self.fake_todo_repository = mocker.Mock()
         self.delete_todo_uc = DeleteTodo(todo_repo=self.fake_todo_repository)
 
-    def test_delete_todo(self):
-        self.fake_todo_repository.find_by_id.return_value = self.fake_todo
+    @mock.patch(f"{MODULE}.get_todo.GetTodo")
+    def test_delete_todo(self, mocked_gettodo):
+        fake_gettodo = mock.Mock()
+        fake_gettodo.call.return_value = self.fake_todo
+        mocked_gettodo.return_value = fake_gettodo
 
-        ret = self.delete_todo_uc.call(id=str(self.fake_todo.id))
+        id_str = str(self.fake_todo.id)
 
-        self.fake_todo_repository.find_by_id.assert_called_once_with(id=self.fake_todo.id)
+        ret = self.delete_todo_uc.call(id=id_str)
+
+        mocked_gettodo.assert_called_once_with(todo_repo=self.fake_todo_repository)
+        fake_gettodo.call.assert_called_once_with(id=id_str)
         self.fake_todo_repository.delete.assert_called_once_with(id=self.fake_todo.id)
         assert ret is None
 
@@ -34,14 +40,3 @@ class TestGetTodo(TestCase):
             self.delete_todo_uc.call(id=fake_id)
         except TodoInvalidIdFormatException as exc:
             assert fake_id in str(exc)
-
-    def test_get_todo_not_found(self):
-        self.fake_todo_repository.find_by_id.return_value = None
-
-        try:
-            self.delete_todo_uc.call(id=str(self.fake_todo.id))
-        except TodoNotFoundException as exc:
-            assert exc.id == self.fake_todo.id
-
-        self.fake_todo_repository.find_by_id.assert_called_once_with(id=self.fake_todo.id)
-        self.fake_todo_repository.delete.assert_not_called()

--- a/tests/use_cases/test_exceptions.py
+++ b/tests/use_cases/test_exceptions.py
@@ -1,0 +1,11 @@
+from uuid import uuid4
+
+from todo_sample.use_cases.exceptions import TodoNotFoundException
+
+
+def test_todonotfoundexception():
+    fake_id = uuid4()
+    exc = TodoNotFoundException(id=fake_id)
+
+    assert exc.id == fake_id
+    assert f"Todo with id:{fake_id} not found." == str(exc)

--- a/tests/use_cases/test_exceptions.py
+++ b/tests/use_cases/test_exceptions.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from todo_sample.use_cases.exceptions import TodoNotFoundException
+from todo_sample.use_cases.exceptions import TodoAlreadyExistException, TodoNotFoundException
 
 
 def test_todonotfoundexception():
@@ -9,3 +9,11 @@ def test_todonotfoundexception():
 
     assert exc.id == fake_id
     assert f"Todo with id:{fake_id} not found." == str(exc)
+
+
+def test_todoalreadyexistexception():
+    fake_id = uuid4()
+    exc = TodoAlreadyExistException(id=fake_id)
+
+    assert exc.id == fake_id
+    assert f"Todo with id:{fake_id} already exist." == str(exc)

--- a/tests/use_cases/test_get_todo.py
+++ b/tests/use_cases/test_get_todo.py
@@ -40,6 +40,6 @@ class TestGetTodo(TestCase):
         try:
             self.get_todo_uc.call(id=str(self.fake_todo.id))
         except TodoNotFoundException as exc:
-            assert str(self.fake_todo.id) in str(exc)
+            assert exc.id == self.fake_todo.id
 
         self.fake_todo_repository.find_by_id.assert_called_once_with(id=self.fake_todo.id)

--- a/tests/use_cases/test_get_todo.py
+++ b/tests/use_cases/test_get_todo.py
@@ -1,0 +1,45 @@
+from unittest import TestCase
+
+import pytest
+
+from todo_sample.entities.todo import Todo
+from todo_sample.use_cases.exceptions import GetTodoInvalidIdFormatException, GetTodoNotFoundException
+from todo_sample.use_cases.get_todo import GetTodo
+
+MODULE = "todo_sample.use_cases.get_todo"
+
+
+class TestGetTodo(TestCase):
+    @pytest.fixture(autouse=True)
+    def _fake_todo_fixture(self, mocker):
+        self.fake_todo = Todo(title="title", description="description")
+
+    @pytest.fixture(autouse=True)
+    def _fake_todo_repo_fixture(self, mocker):
+        self.fake_todo_repository = mocker.Mock()
+        self.get_todo_uc = GetTodo(todo_repo=self.fake_todo_repository)
+
+    def test_get_todo(self):
+        self.fake_todo_repository.find_by_id.return_value = self.fake_todo
+
+        todo = self.get_todo_uc.call(id=str(self.fake_todo.id))
+
+        self.fake_todo_repository.find_by_id.assert_called_once_with(id=self.fake_todo.id)
+        assert self.fake_todo == todo
+
+    def test_get_todo_wrong_id_format(self):
+        fake_id = "some-wrong-format-id"
+        try:
+            self.get_todo_uc.call(id=fake_id)
+        except GetTodoInvalidIdFormatException as exc:
+            assert fake_id in str(exc)
+
+    def test_get_todo_not_found(self):
+        self.fake_todo_repository.find_by_id.return_value = None
+
+        try:
+            self.get_todo_uc.call(id=str(self.fake_todo.id))
+        except GetTodoNotFoundException as exc:
+            assert str(self.fake_todo.id) in str(exc)
+
+        self.fake_todo_repository.find_by_id.assert_called_once_with(id=self.fake_todo.id)

--- a/tests/use_cases/test_get_todo.py
+++ b/tests/use_cases/test_get_todo.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import pytest
 
 from todo_sample.entities.todo import Todo
-from todo_sample.use_cases.exceptions import GetTodoInvalidIdFormatException, GetTodoNotFoundException
+from todo_sample.use_cases.exceptions import TodoInvalidIdFormatException, TodoNotFoundException
 from todo_sample.use_cases.get_todo import GetTodo
 
 MODULE = "todo_sample.use_cases.get_todo"
@@ -31,7 +31,7 @@ class TestGetTodo(TestCase):
         fake_id = "some-wrong-format-id"
         try:
             self.get_todo_uc.call(id=fake_id)
-        except GetTodoInvalidIdFormatException as exc:
+        except TodoInvalidIdFormatException as exc:
             assert fake_id in str(exc)
 
     def test_get_todo_not_found(self):
@@ -39,7 +39,7 @@ class TestGetTodo(TestCase):
 
         try:
             self.get_todo_uc.call(id=str(self.fake_todo.id))
-        except GetTodoNotFoundException as exc:
+        except TodoNotFoundException as exc:
             assert str(self.fake_todo.id) in str(exc)
 
         self.fake_todo_repository.find_by_id.assert_called_once_with(id=self.fake_todo.id)

--- a/tests/use_cases/test_get_todos.py
+++ b/tests/use_cases/test_get_todos.py
@@ -1,0 +1,13 @@
+from todo_sample.use_cases.get_todos import GetTodos
+
+MODULE = "todo_sample.use_cases.get_todos"
+
+
+def test_get_todos(mocker):
+    fake_todo_repository = mocker.Mock()
+    get_todos_uc = GetTodos(todo_repo=fake_todo_repository)
+
+    todos = get_todos_uc.call()
+
+    assert fake_todo_repository.get_all.return_value == todos
+    fake_todo_repository.get_all.assert_called_once()

--- a/tests/use_cases/test_update_todo.py
+++ b/tests/use_cases/test_update_todo.py
@@ -1,0 +1,62 @@
+from datetime import datetime
+from unittest import TestCase, mock
+
+import pytest
+
+from todo_sample.entities.todo import Todo, TodoUpdate
+from todo_sample.use_cases.update_todo import UpdateTodo
+
+MODULE = "todo_sample.use_cases.update_todo"
+
+
+class TestUpdateTodo(TestCase):
+    @pytest.fixture(autouse=True)
+    def _fake_todo_fixture(self, mocker):
+        self.fake_todo = Todo(title="title", description="description")
+
+    @pytest.fixture(autouse=True)
+    def _fake_todo_repo_fixture(self, mocker):
+        self.fake_todo_repository = mocker.Mock()
+        self.get_todo_uc = UpdateTodo(todo_repo=self.fake_todo_repository)
+
+    def test_nothing_to_do_empty_payload(self):
+        todo_update = TodoUpdate()
+
+        updated_todo = self.get_todo_uc.call(id=str(self.fake_todo.id), todo_update=todo_update)
+
+        assert updated_todo is None
+
+    def test_nothing_to_do_same_value(self):
+        todo_update = TodoUpdate(title=self.fake_todo.title)
+        self.fake_todo_repository.find_by_id.return_value = self.fake_todo
+        updated_todo = self.get_todo_uc.call(id=str(self.fake_todo.id), todo_update=todo_update)
+
+        self.fake_todo_repository.find_by_id.assert_called_once_with(id=self.fake_todo.id)
+        assert updated_todo is None
+
+    def test_update_all(self):
+        fake_now = datetime.utcnow()
+        self.fake_todo_repository.find_by_id.return_value = self.fake_todo
+
+        new_title = f"{self.fake_todo.title}-updated"
+        new_description = f"{self.fake_todo.description}-updated"
+        new_done = not self.fake_todo.done
+
+        todo_update = TodoUpdate(title=new_title, description=new_description, done=new_done)
+        expected_updated_todo = Todo(
+            id=self.fake_todo.id,
+            title=new_title,
+            description=new_description,
+            done=new_done,
+            created_at=self.fake_todo.created_at,
+            updated_at=fake_now,
+        )
+
+        with mock.patch(f"{MODULE}.datetime") as fake_datetime:
+            fake_datetime.utcnow.return_value = fake_now
+
+            updated_todo = self.get_todo_uc.call(id=str(self.fake_todo.id), todo_update=todo_update)
+
+        self.fake_todo_repository.find_by_id.assert_called_once_with(id=self.fake_todo.id)
+        self.fake_todo_repository.save.assert_called_once_with(todo=updated_todo, create_only=False)
+        assert updated_todo == expected_updated_todo

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,9 @@ commands =
 
 ## Typing
 [testenv:mypy]
-extras = typing
+extras =
+    typing
+    testing
 commands =
     mypy --config-file setup.cfg
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,9 +33,7 @@ commands =
 
 ## Typing
 [testenv:mypy]
-deps =
-    mypy
-extras = testing
+extras = typing
 commands =
     mypy --config-file setup.cfg
 


### PR DESCRIPTION
## What does this PR do?

- add Basic CRUB operation for todo
- add new Todo model for update/patch operation
- split mypy requirement to new extra and update tox env for mypy

## Motivation

- main app UC
- tox mypy env only required (new) typing extra


## Additional Notes

- Dependency Injection framework is not yet chose for the repository
- Missing filtering (eg: title beging with, title equal, size, limit, ...)

- thinking about if we should mock all code reference or not (see: https://github.com/Oltho/todo-clean-architecture-sample/commit/1662232f61aa9a1fe449f66fec97bf63042e5a47 https://github.com/Oltho/todo-clean-architecture-sample/pull/5/commits/a3402a503c2dda33b51ede5c7980ecb6c7acdaef)